### PR TITLE
实例化玩家角色并修复碰撞器设置

### DIFF
--- a/Assets/Prefabs/2D Maps/Underground Boxing Gym.prefab
+++ b/Assets/Prefabs/2D Maps/Underground Boxing Gym.prefab
@@ -620,7 +620,8 @@ EdgeCollider2D:
   m_Offset: {x: 0, y: -1.64}
   m_EdgeRadius: 0
   m_Points:
-  - {x: 9.950452, y: -0.017474532}
+  - {x: 0.06721598, y: 0.008096337}
+  - {x: 9.946344, y: -0.013447881}
   - {x: 10.7684555, y: 0.14627528}
   - {x: 10.995965, y: 1.0143639}
   - {x: 13.77972, y: 1.0097133}
@@ -632,11 +633,12 @@ EdgeCollider2D:
   - {x: -13.964818, y: -4.423993}
   - {x: -13.909794, y: 0.7344718}
   - {x: -9.808968, y: 0.7113005}
-  - {x: -9.559605, y: -0.015413642}
+  - {x: -9.209201, y: -0.047663808}
+  - {x: 0.0005584359, y: 0.0081881285}
   m_AdjacentStartPoint: {x: 0, y: 0}
   m_AdjacentEndPoint: {x: 0, y: 0}
-  m_UseAdjacentStartPoint: 1
-  m_UseAdjacentEndPoint: 1
+  m_UseAdjacentStartPoint: 0
+  m_UseAdjacentEndPoint: 0
 --- !u!1 &3927702912832927376
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Level2D/Player Character 2D.prefab
+++ b/Assets/Resources/Level2D/Player Character 2D.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &4469421218970653765
+--- !u!1 &2793922551257917759
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,81 +8,65 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4132782471594626613}
-  - component: {fileID: 4495463554606869876}
-  - component: {fileID: 7919608459311822951}
+  - component: {fileID: 8734036891288680329}
+  - component: {fileID: 4167142379183797378}
   m_Layer: 0
-  m_Name: Sprite
+  m_Name: Collider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &4132782471594626613
+  m_IsActive: 1
+--- !u!4 &8734036891288680329
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4469421218970653765}
+  m_GameObject: {fileID: 2793922551257917759}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.5, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6104192319944126911}
+  m_Father: {fileID: 8103820850881256293}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &4495463554606869876
-MeshFilter:
+--- !u!70 &4167142379183797378
+CapsuleCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4469421218970653765}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &7919608459311822951
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4469421218970653765}
+  m_GameObject: {fileID: 2793922551257917759}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a961c1f0bb4602e45a2e1029f013f173, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 1, y: 0.2}
+  m_Direction: 1
 --- !u!1 &5210199871147977087
 GameObject:
   m_ObjectHideFlags: 0
@@ -112,7 +96,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 4132782471594626613}
   - {fileID: 108838766449436743}
   m_Father: {fileID: 8103820850881256293}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -148,6 +131,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6104192319944126911}
+  - {fileID: 8734036891288680329}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!50 &5169911673293718804
@@ -191,7 +175,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rigidbody2D: {fileID: 5169911673293718804}
   MoveSpeed: 2.5
-  layerMask:
+  interactionLayerMask:
     serializedVersion: 2
     m_Bits: 0
 --- !u!1 &6644313131752306132

--- a/Assets/Scripts/Core/Level2D/LevelController.cs
+++ b/Assets/Scripts/Core/Level2D/LevelController.cs
@@ -14,8 +14,13 @@ namespace Core.Level2D
             get => _playerCharacter;
         }
 
-        [SerializeField]
+        // [SerializeField]
         private Map _map;
+        public Map Map
+        {
+            get => _map;
+            private set => _map = value;
+        }
 
         [SerializeField]
         private CameraController _cameraController;
@@ -27,6 +32,11 @@ namespace Core.Level2D
             if (map != null)
             {
                 SetMap(map);
+                // Instantiate Player Character
+                GameObject playerCharacterPrefab = Resources.Load<GameObject>("Level2D/Player Character 2D");
+                Vector2 mainEntrance = Map.mainEntrance;
+                Vector3 position = new Vector3(mainEntrance.x, mainEntrance.y, mainEntrance.y);
+                SetPlayerCharacter(Instantiate(playerCharacterPrefab, position, Quaternion.identity).GetComponent<PlayerCharacter>());
             }
         }
 

--- a/Assets/Scripts/Core/Level2D/LevelController.cs
+++ b/Assets/Scripts/Core/Level2D/LevelController.cs
@@ -14,7 +14,7 @@ namespace Core.Level2D
             get => _playerCharacter;
         }
 
-        // [SerializeField]
+
         private Map _map;
         public Map Map
         {
@@ -32,11 +32,16 @@ namespace Core.Level2D
             if (map != null)
             {
                 SetMap(map);
-                // Instantiate Player Character
-                GameObject playerCharacterPrefab = Resources.Load<GameObject>("Level2D/Player Character 2D");
-                Vector2 mainEntrance = Map.mainEntrance;
-                Vector3 position = new Vector3(mainEntrance.x, mainEntrance.y, mainEntrance.y);
-                SetPlayerCharacter(Instantiate(playerCharacterPrefab, position, Quaternion.identity).GetComponent<PlayerCharacter>());
+
+                // 仅在当前没有通过 Inspector 或其他方式绑定玩家时，才实例化玩家预制体
+                if (_playerCharacter == null)
+                {
+                    // Instantiate Player Character
+                    GameObject playerCharacterPrefab = Resources.Load<GameObject>("Level2D/Player Character 2D");
+                    Vector2 mainEntrance = Map.mainEntrance;
+                    Vector3 position = new Vector3(mainEntrance.x, mainEntrance.y, mainEntrance.y);
+                    SetPlayerCharacter(Instantiate(playerCharacterPrefab, position, Quaternion.identity).GetComponent<PlayerCharacter>());
+                }
             }
         }
 

--- a/Assets/Sprites/Player/玩家占位符.png.meta
+++ b/Assets/Sprites/Player/玩家占位符.png.meta
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c2e2fb6dbe9465cf4bc990a7c74617f3f9d53462cbc2ea6eadbfa21a80b478d3
-size 2761
+oid sha256:57290012603b2938fcb97c5b29f732e771f56e3a1ee0d5206a2bc7129ab35503
+size 2647


### PR DESCRIPTION
在关卡唤醒时实例化玩家角色，并更新玩家角色的碰撞设置以确保正确的定位和激活。此外，调整边缘碰撞器的点坐标和使用状态，以改进游戏机制。